### PR TITLE
Fixed LSTM bmi config elevation and lat/lon unit bug

### DIFF
--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -791,6 +791,10 @@ class RealizationBuilder:
                                           crs="EPSG:5070")
         self.attr_file = self.attr_file.to_crs("EPSG:4326")
 
+        # Update coordinates with reprojected values
+        self.attr_file[x_col] = self.attr_file.geometry.x
+        self.attr_file[y_col] = self.attr_file.geometry.y
+
         logger.info(f"Attribute file loaded from: {self.gpkg_file}")
 
     def _extract_forcing(self):

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -1262,7 +1262,7 @@ def create_lstm_input(
 
         area = float(df_divide.loc[catID]['areasqkm'])
         slope = float(dfa.loc[catID]['mean.slope'])
-        elev = float(dfa.loc[catID]['mean.elevation'])
+        elev = float(dfa.loc[catID]['mean.elevation']) / 100
         lat = float(dfa.loc[catID][xy_col[1]])
         lon = float(dfa.loc[catID][xy_col[0]])
 


### PR DESCRIPTION
Yuqiong reported an error with nwm-msw-mgr created BMI config files for LSTM in https://jira.nextgenwaterprediction.com/browse/NGWPC-7645. When EDFS bmi_dir was not provided, elevation was in the wrong units and lat/lon were in the wrong projection.

I added a unit conversion for catchment elevation in the LSTM files to match those provided by EDFS.
I also updated the x/y coordinate columns in the divide-attributes file with values in EPSG:4326.