### PR TITLE
Added logic for catching missing ice_fraction_scheme in SFT configs

### DIFF
--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -1830,9 +1830,12 @@ def change_sft_input(
             lines0 = f.readlines()
         lines1 = copy.deepcopy(lines0)
 
-        # Find index of ice_fraction_scheme line
+        # Find index of ice_fraction_scheme line and update icefscheme
         idx = [i for i, s in enumerate(lines0) if s.startswith('ice')]
-        lines1[idx[0]] = f'ice_fraction_scheme={icefscheme}\n'
+        if len(idx) > 0:
+            lines1[idx[0]] = f'ice_fraction_scheme={icefscheme}\n'
+        else:
+            lines1.append(f'ice_fraction_scheme={icefscheme}\n')
 
         # Save to new parameter file
         with open(param_file, 'w') as outfile:


### PR DESCRIPTION
Christina found the following error for an sft formulation:

  File "/ngencerf/ngencerf-python/lib64/python3.11/site-packages/mswm/build_inputs.py", line 983, in _create_bmi_configs
    gfun.change_sft_input(self.catids, modules1, mod_input_dir, bmi_dir, self.run_type)
  File "/ngencerf/ngencerf-python/lib64/python3.11/site-packages/mswm/utils/ginputfunc.py", line 1835, in change_sft_input
    lines1[idx[0]] = f'ice_fraction_scheme={icefscheme}\n'
           ~~~^^^
IndexError: list index out of range

I was unable to reproduce the error but I believe it was caused by a missing 'ice_fraction_scheme' field in a EDFS SFT bmi config file. I added a check to make sure that the field is present before trying to update it with the correct scheme. If the field is not present in the provided BMI config file, it will be added as the last line of the file.