### PR TITLE
Update cold start file naming and lookback

### DIFF
--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -383,9 +383,15 @@ class RealizationBuilder:
             self.cycle_date = cycle_dt.strftime("%Y-%m-%d")
             self.cycle_hour = cycle_dt.strftime("%H") + "z"
 
+            # Construct forecing template file name
+            if self.use_cold_start:
+                forcing_region = next((f"_{reg}" for reg in ["alaska", "hawaii", "puertorico"] if reg in self.forecast_configuration), "")
+                self.forecast_configuration_str = f"cold_start{forcing_region}_config.yml"
+            else:
+                self.forecast_configuration_str = f"{self.forecast_configuration}_config.yml"
+
             # Ensure forcing template file exists
-            forecast_configuration_str = 'cold_start' if self.use_cold_start else self.forecast_configuration
-            self.forcing_template_file = (Path(self.forcing_template_dir) / f"{forecast_configuration_str}_config.yml").absolute()
+            self.forcing_template_file = (Path(self.forcing_template_dir) / self.forecast_configuration_str).absolute()
             if not self.forcing_template_file.exists():
                 try:
                     raise FileNotFoundError(f'Forcing template file does not exist: {self.forcing_template_file}')
@@ -901,18 +907,14 @@ class RealizationBuilder:
 
             # Set target directory for forcing config file
             self.forcing_config_dir = Path(self.input_dir) / 'forcing_config'
-
-            if self.use_cold_start is True:
-                self.forcing_config_file = self.forcing_config_dir / "cold_start_config.yml"
-            else:
-                self.forcing_config_file = self.forcing_config_dir / f"{self.forecast_configuration}_config.yml"
+            self.forcing_config_file = self.forcing_config_dir / self.forecast_configuration_str
 
             # Construct ESMF mesh file path
-            gpkg_name = os.path.splitext(os.path.basename(self.cat_file))[0]
+            gpkg_name = os.path.splitext(os.path.basename(self.gpkg_cats))[0]
             self.geogrid_file = f"/ngen-app/data/esmf_mesh/{gpkg_name}_ESMF_Mesh.nc"
 
             # Update dynamic parameters in forcing engine configuration file
-            gfun.update_forcing_config(self.cycle_date, self.cycle_hour, self.forcing_template, self.cat_file, self.geogrid_file, self.forcing_config_dir, self.forcing_config_file, self.use_cold_start, self.cold_start_datetime)
+            gfun.update_forcing_config(self.cycle_date, self.cycle_hour, self.forcing_template, self.gpkg_cats, self.geogrid_file, self.forcing_config_dir, self.forcing_config_file, self.use_cold_start, self.cold_start_datetime)
 
             logger.info(f"Configured BMI forcing engine: {self.forcing_config_file}")
 

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -2394,15 +2394,13 @@ def update_forcing_config(
     cycle_dt = datetime.datetime.strptime(cycle_date, "%Y-%m-%d").replace(hour=int(cycle_hour.replace("z", "")))
     cycle_str = cycle_dt.strftime('%Y%m%d%H%M')
 
-    # Set Refcstbdateproc
+    # Set lookback minutes for cold start period
     if use_cold_start is True:
         cold_start_dt = datetime.datetime.strptime(cold_start_datetime, "%Y-%m-%d %H:%M:%S")
-        refcstbdateproc = (cold_start_dt + datetime.timedelta(hours=1)).strftime("%Y%m%d%H%M")
-    else:
-        refcstbdateproc = cycle_str
+        forcing_template['LookBack'] = int((cycle_dt - cold_start_dt).total_seconds() / 60)
 
     # Update forcing_template with dynamic variables
-    forcing_template['RefcstBDateProc'] = refcstbdateproc
+    forcing_template['RefcstBDateProc'] = cycle_str
     forcing_template['GeogridIn'] = geogrid_file
     forcing_template['Geopackage'] = gpkg_file
 


### PR DESCRIPTION
Add functionality to infer cold_start forcing engine configuration file from main forecast cycle and update lookback hours in config file from code_start_datetime.