### PR TITLE
Jwade fix forcing dir

### DIFF
--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -1150,7 +1150,7 @@ class RealizationBuilder:
                         gfun.create_cfe_input(self.catids, ['cfes'] + [self.modules], self.attr_file, cfe_dir, self.run_type, self.is_aet_rootzone)
 
                     # Create sft input
-                    gfun.create_sft_smp_input(self.catids, self.modules, self.attr_parquet, cfe_dir, self.conf3['forcing_dir'], sft_dir, smp_dir, self.run_type)
+                    gfun.create_sft_smp_input(self.catids, self.modules, self.attr_parquet, cfe_dir, self.forcing_dir, sft_dir, smp_dir, self.run_type)
 
                 elif m1 == 'smp':
                     continue
@@ -1359,7 +1359,7 @@ class RealizationBuilder:
                                 gfun.create_cfe_input(scheme_cat, scheme_form_cfes, self.attr_file, cfe_dir, self.run_type, self.cat_to_aet_rootzone)
 
                             # Create SFT/SMP inputs
-                            gfun.create_sft_smp_input(scheme_cat, scheme_form, self.attr_parquet, cfe_dir, self.conf3['forcing_dir'], sft_dir, smp_dir, self.run_type)
+                            gfun.create_sft_smp_input(scheme_cat, scheme_form, self.attr_parquet, cfe_dir, self.forcing_dir, sft_dir, smp_dir, self.run_type)
 
                 # Skip smp, inputs created in tandem with sft
                 elif m1 == 'smp':

--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -1147,7 +1147,7 @@ class RealizationBuilder:
                     else:
                         # If CFE BMI config files not provided and cfe not in modules, create cfe input files
                         cfe_dir = os.path.join(self.input_dir, 'cfe-s_input')
-                        gfun.create_cfe_input(self.catids, ['cfes'] + [self.modules], self.attr_file, cfe_dir, self.run_type, self.is_aet_rootzone)
+                        gfun.create_cfe_input(self.catids, ['cfes'] + [self.modules], self.attr_file, cfe_dir, self.run_type, 0)
 
                     # Create sft input
                     gfun.create_sft_smp_input(self.catids, self.modules, self.attr_parquet, cfe_dir, self.forcing_dir, sft_dir, smp_dir, self.run_type)


### PR DESCRIPTION
Fix minor error in forcing_dir variable for SFT. Also updated the aet_rootzone default value when running lasam, which uses CFE files for parameters.