### PR TITLE
Jwade ngwpc 8636 update bmi config params

### DIFF
--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -1066,7 +1066,7 @@ class RealizationBuilder:
                 if m1 in ['cfes', 'cfex']:
                     gfun.create_cfe_input(self.catids, self.modules, self.attr_file, mod_input_dir, self.run_type, self.is_aet_rootzone)
                 elif m1 == 'topmodel':
-                    gfun.create_topmodel_input(self.catids, self.attr_file, self.gpkg_file, mod_input_dir)
+                    gfun.create_topmodel_input(self.catids, self.attr_file, self.divides_layer, mod_input_dir)
                 elif m1 == 'ueb':
                     gfun.create_ueb_input(self.catids, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, '', self.run_type)
                 elif m1 == 'snow17':
@@ -1241,7 +1241,7 @@ class RealizationBuilder:
                 if m1 in ['cfes', 'cfex']:
                     gfun.create_cfe_input(cat_mod, form_cat, self.attr_file, mod_input_dir, self.run_type, self.cat_to_aet_rootzone)
                 elif m1 == 'topmodel':
-                    gfun.create_topmodel_input(cat_mod, self.attr_file, self.gpkg_file, mod_input_dir)
+                    gfun.create_topmodel_input(cat_mod, self.attr_file, self.divides_layer, mod_input_dir)
                 elif m1 == 'ueb':
                     gfun.create_ueb_input(cat_mod, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, '', self.run_type)
                 elif m1 == 'snow17':

--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -853,42 +853,22 @@ class RealizationBuilder:
 
         # Read catchment parameter values from geopackage divide-attributes
         try:
-            attr_input = gpd.read_file(self.gpkg_file, layer='divide-attributes')
-            attr_input.set_index("divide_id", inplace=True)
+            self.attr_file = gpd.read_file(self.gpkg_file, layer='divide-attributes')
+            self.attr_file.set_index("divide_id", inplace=True)
         except Exception as e:
             logger.critical(f"Error while reading geopackage file: {e}")
             raise
 
-        # Adapt to x,y column name in geopackage
-        x_cols = ["centroid_x", "X"]
-        y_cols = ["centroid_y", "Y"]
-        x_col = next((c for c in x_cols if c in attr_input.columns), None)
-        y_col = next((c for c in y_cols if c in attr_input.columns), None)
-        self.xy_col = [x_col, y_col]
-
-        if not x_col or y_col:
-            try:
-                Exception("Could not find coordinate columns in geopackage `divide-attributes`")
-            except Exception as e:
-                logger.critical(f"Error while reading geopackage file: {e}")
-                raise
-
-        # Reproject to WGS84 for X,Y coordinates
-        self.attr_file = gpd.GeoDataFrame(attr_input,
-                                          geometry=gpd.points_from_xy(attr_input[x_col], attr_input[y_col]),
-                                          crs="EPSG:5070")
-        self.attr_file = self.attr_file.to_crs("EPSG:4326")
-
-        # Update coordinates with reprojected values
-        self.attr_file[x_col] = self.attr_file.geometry.x
-        self.attr_file[y_col] = self.attr_file.geometry.y
-
-        # Read catchment ids from geopackage
+        # Read catchment divide layer from hydrofabric
         try:
-            self.catids = gpd.read_file(self.gpkg_file, layer='divides')['divide_id'].tolist()
+            self.divides_layer = gpd.read_file(self.gpkg_file, layer='divides')
+            self.catids = self.divides_layer['divide_id'].tolist()
         except Exception as e:
             logger.critical(f"Error while reading geopackage file: {e}")
             raise
+
+        # Update hydrofabic attribute names based on region and minor parameter value fixes
+        self.attr_file = gfun.change_hydrofab_attr(self.attr_file, self.divides_layer)
 
         logger.info(f"Attribute file loaded from: {self.gpkg_file}")
 

--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -1085,35 +1085,11 @@ class RealizationBuilder:
                 elif m1 == 'sft':
                     sft_dir = os.path.join(self.input_dir, 'sft_input')
                     smp_dir = os.path.join(self.input_dir, 'smp_input')
-
-                    # Update CFE bmi dir with correct scheme (Schaake/Xinanjiang)
-                    if ('cfes' in self.modules):
-                        # If bmi_dir not provided by input file, create from input dir
-                        if self.conf3['cfe_s_bmi_dir'] is None:
-                            cfe_dir = os.path.join(self.input_dir, 'cfe-s_input')
-                        # If bmi_dir provided by input file, use that path
-                        else:
-                            cfe_dir = self.conf3['cfe_s_bmi_dir']
-                    elif ('cfex' in self.modules):
-                        # If bmi_dir not provided by input file, create from input dir
-                        if self.conf3['cfe_x_bmi_dir'] is None:
-                            cfe_dir = os.path.join(self.input_dir, 'cfe-x_input')
-                        # If bmi_dir provided by input file, use that path
-                        else:
-                            cfe_dir = self.conf3['cfe_x_bmi_dir']
-                    else:
-                        # If CFE BMI config files not provided and cfe not in modules, create cfe input files
-                        cfe_dir = os.path.join(self.input_dir, 'cfe-s_input')
-                        gfun.create_cfe_input(self.catids, ['cfes'] + [self.modules], self.attr_file, cfe_dir, self.run_type, 0)
-
-                    # Create sft input
-                    gfun.create_sft_smp_input(self.catids, self.modules, self.attr_parquet, cfe_dir, self.forcing_dir, sft_dir, smp_dir, self.run_type)
-
+                    gfun.create_sft_smp_input(self.catids, self.modules, self.attr_file, sft_dir, smp_dir, self.run_type)
                 elif m1 == 'smp':
                     continue
                 elif m1 == 'lasam':
                     gfun.create_lasam_input(self.catids, self.modules, self.attr_file, mod_input_dir, self.conf3['lasam_parameter_dir'], self.run_type)
-
                 elif m1 == 'troute':
                     if self.run_type == 'calibration':
                         run_names = ['calib', 'valid', 'valid']
@@ -1290,40 +1266,20 @@ class RealizationBuilder:
                     for scheme in ['cfes', 'cfex', 'lasam']:
                         # Retrieve formulation groups where CFES/CFEX/LASAM co-occur with SFT
                         scheme_sft_grps = [grp for grp, mods in self.grp_to_form.items() if scheme in mods and 'sft' in mods]
-                        if scheme_sft_grps:
-                            # Update CFE bmi dir with correct scheme for formulation (Schaake/Xinanjiang)
-                            if scheme == 'cfes' or scheme == 'lasam':
-                                scheme_bmi_var = 'cfe-s'
-                            elif scheme == 'cfex':
-                                scheme_bmi_var = 'cfe-x'
-                            else:
-                                try:
-                                    raise Exception('SMP/SFT only implemented when CFE-S, CFE-X, or LASAM are selected')
-                                except Exception as e:
-                                    logger.critical(e)
-                                    raise
 
+                        if scheme_sft_grps:
                             # Retrieve catchments and formulations corresponding to scheme
                             scheme_cat = [cat for grp in scheme_sft_grps for cat in self.grp_to_cat[grp]]
                             scheme_form = [self.cat_to_form[cat] for cat in scheme_cat]
 
-                            # Form CFE input dir
-                            cfe_dir = os.path.join(self.input_dir, scheme_bmi_var + '_input')
-
-                            # If LASAM is selected, create cfe input files required for sft (assume ice_fraction_scheme is cfes)
-                            if scheme not in ('cfes', 'cfex'):
-                                scheme_form_cfes = [form + ['cfes'] for form in scheme_form]
-                                gfun.create_cfe_input(scheme_cat, scheme_form_cfes, self.attr_file, cfe_dir, self.run_type, self.cat_to_aet_rootzone)
-
                             # Create SFT/SMP inputs
-                            gfun.create_sft_smp_input(scheme_cat, scheme_form, self.attr_parquet, cfe_dir, self.forcing_dir, sft_dir, smp_dir, self.run_type)
+                            gfun.create_sft_smp_input(scheme_cat, scheme_form, self.attr_file, sft_dir, smp_dir, self.run_type)
 
                 # Skip smp, inputs created in tandem with sft
                 elif m1 == 'smp':
                     continue
                 elif m1 == 'lasam':
                     gfun.create_lasam_input(cat_mod, form_cat, self.attr_file, mod_input_dir, self.conf3['lasam_parameter_dir'], self.run_type)
-
                 elif m1 == 'troute':
                     for file_name, run_name in zip(self.run_configs, ['region']):
                         routing_config_file = os.path.join(self.work_dir + '/Input', '{}'.format(self.basin) + file_name)
@@ -1333,7 +1289,6 @@ class RealizationBuilder:
                             nts = len(pd.date_range(start=run_range[0], end=run_range[1], freq='5min')) - 1
                             gfun.create_troute_config(self.gpkg_file, routing_config_file, self.time_period['run_time_period'][run_name][0], nts)
                             logger.info(f'troute config file for {run_name1} is created at: {routing_config_file}')
-
                 if m1 != 'troute':
                     logger.info(f'{m1}: input config files created at: {mod_input_dir}')
 

--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -1074,11 +1074,11 @@ class RealizationBuilder:
                 elif m1 == "pet":
                     gfun.create_pet_input(self.catids, self.attr_file, mod_input_dir)
                 elif m1 == "sac":
-                    gfun.create_sac_input(self.catids, self.gpkg_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir)
+                    gfun.create_sac_input(self.catids, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir)
                 elif m1 == 'noah':
                     gfun.create_noah_input(self.catids, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, self.run_type)
                 elif m1 == 'lstm':
-                    gfun.create_lstm_input(self.catids, self.attr_file, self.gpkg_file, self.conf3['lstm_parameter_dir'], mod_input_dir, self.xy_col)
+                    gfun.create_lstm_input(self.catids, self.attr_file, self.conf3['lstm_parameter_dir'], mod_input_dir)
                 elif m1 == 'sft':
                     sft_dir = os.path.join(self.input_dir, 'sft_input')
                     smp_dir = os.path.join(self.input_dir, 'smp_input')
@@ -1249,11 +1249,11 @@ class RealizationBuilder:
                 elif m1 == "pet":
                     gfun.create_pet_input(cat_mod, self.attr_file, mod_input_dir)
                 elif m1 == "sac":
-                    gfun.create_sac_input(cat_mod, self.gpkg_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir)
+                    gfun.create_sac_input(cat_mod, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir)
                 elif m1 == 'noah':
                     gfun.create_noah_input(cat_mod, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, self.run_type)
                 elif m1 == 'lstm':
-                    gfun.create_lstm_input(cat_mod, self.attr_file, self.gpkg_file, self.conf3['lstm_parameter_dir'], mod_input_dir, self.xy_col)
+                    gfun.create_lstm_input(cat_mod, self.attr_file, self.conf3['lstm_parameter_dir'], mod_input_dir)
                 elif m1 == 'sft':
                     sft_dir = os.path.join(self.input_dir, 'sft_input')
                     smp_dir = os.path.join(self.input_dir, 'smp_input')

--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -1066,7 +1066,7 @@ class RealizationBuilder:
                 if m1 in ['cfes', 'cfex']:
                     gfun.create_cfe_input(self.catids, self.modules, self.attr_file, mod_input_dir, self.run_type, self.is_aet_rootzone)
                 elif m1 == 'topmodel':
-                    gfun.create_topmodel_input(self.catids, self.attr_file, self.divides_layer, mod_input_dir)
+                    gfun.create_topmodel_input(self.catids, self.attr_file, mod_input_dir)
                 elif m1 == 'ueb':
                     gfun.create_ueb_input(self.catids, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, '', self.run_type)
                 elif m1 == 'snow17':
@@ -1241,7 +1241,7 @@ class RealizationBuilder:
                 if m1 in ['cfes', 'cfex']:
                     gfun.create_cfe_input(cat_mod, form_cat, self.attr_file, mod_input_dir, self.run_type, self.cat_to_aet_rootzone)
                 elif m1 == 'topmodel':
-                    gfun.create_topmodel_input(cat_mod, self.attr_file, self.divides_layer, mod_input_dir)
+                    gfun.create_topmodel_input(cat_mod, self.attr_file, mod_input_dir)
                 elif m1 == 'ueb':
                     gfun.create_ueb_input(cat_mod, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, '', self.run_type)
                 elif m1 == 'snow17':

--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -360,9 +360,6 @@ class RealizationBuilder:
         if not self.parallelSec or self.parallelSec.get("nprocs", 0) < 2:
             self.parallelSec = None
 
-        # Parse attribute file
-        self.attr_parquet = self.conf3['attributes_file'] if self.conf1 else None
-
         logger.info('Input.config sections parsed')
 
     def _parse_forcing_engine(self):

--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -648,46 +648,16 @@ class RealizationBuilder:
         for p1 in settings.modules_all['process']:
             procs = list(set(procs + p1))
 
-        for p1 in procs:
-            mods = [m1 for m1 in self.modules if p1 in settings.modules_all.loc[settings.modules_all['module'] == m1, 'process'].values[0]]
+        def validate_formulation(modules, label=None):
+            """Inner helper function to validate a single formulation or grouped formulations"""
 
-            # make sure only one module is selected for each process (except for Soil_moisture and Glacier_snow)
-            if len(mods) > 1 and p1 not in ['Soil_moisture', 'Glacier_snow']:
-                try:
-                    raise Exception(f'Only one module can be selected for {p1} process')
-                except Exception as e:
-                    logger.critical(e)
-                    raise
-
-            # one and only one module must be selected for rainfall-runoff and PET
-            if (p1 in ['Evapotranspiration', 'Rainfall_runoff']) and (len(mods) == 0):
-                try:
-                    raise Exception(f'At least one module must be selected for {p1} process')
-                except Exception as e:
-                    logger.critical(e)
-                    raise
-
-        logger.info("Module processes validated")
-
-    def _validate_reg_processes(self):
-        """
-        Check that each formulation has all required hydrological processes
-        Could be combined with _validate_processes
-        """
-        # check modules selected for each process
-        procs = []
-        for p1 in settings.modules_all['process']:
-            procs = list(set(procs + p1))
-
-        # Loop through formulation group dictionary
-        for grp, form in self.grp_to_form.items():
             for p1 in procs:
-                mods = [m1 for m1 in form if p1 in settings.modules_all.loc[settings.modules_all['module'] == m1, 'process'].values[0]]
+                mods = [m1 for m1 in modules if p1 in settings.modules_all.loc[settings.modules_all['module'] == m1, 'process'].values[0]]
 
                 # make sure only one module is selected for each process (except for Soil_moisture and Glacier_snow)
                 if len(mods) > 1 and p1 not in ['Soil_moisture', 'Glacier_snow']:
                     try:
-                        raise Exception(f'Only one module can be selected for {p1} process: {grp}')
+                        raise Exception(f'Only one module can be selected for {p1} process')
                     except Exception as e:
                         logger.critical(e)
                         raise
@@ -695,12 +665,19 @@ class RealizationBuilder:
                 # one and only one module must be selected for rainfall-runoff and PET
                 if (p1 in ['Evapotranspiration', 'Rainfall_runoff']) and (len(mods) == 0):
                     try:
-                        raise Exception(f'At least one module must be selected for {p1} process: {grp}')
+                        raise Exception(f'At least one module must be selected for {p1} process')
                     except Exception as e:
                         logger.critical(e)
                         raise
 
-            logger.info(f"Module processes validated for {grp}")
+        # Validation formulations using helper function
+        if hasattr(self, 'grp_to_form') and self.grp_to_form:
+            for grp, form in self.grp_to_form.items():
+                validate_formulation(form, label=grp)
+                logger.info(f"Module processes validated for {grp}")
+        else:
+            validate_formulation(self.modules)
+            logger.info("Module processes validated")
 
     def _map_cat_to_grp(self):
         """
@@ -1096,7 +1073,7 @@ class RealizationBuilder:
                 elif m1 == 'ueb':
                     gfun.create_ueb_input(self.catids, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, '', self.run_type)
                 elif m1 == 'snow17':
-                    gfun.create_snow17_input(self.catids, self.attr_file, self.gpkg_file, self.conf3[m2.replace("-", "_") + '_parameter_dir'], mod_input_dir)
+                    gfun.create_snow17_input(self.catids, self.attr_file, self.conf3[m2.replace("-", "_") + '_parameter_dir'], mod_input_dir)
                 elif m1 == "pet":
                     gfun.create_pet_input(self.catids, self.attr_file, mod_input_dir)
                 elif m1 == "sac":
@@ -1295,7 +1272,7 @@ class RealizationBuilder:
                 elif m1 == 'ueb':
                     gfun.create_ueb_input(cat_mod, self.time_period, self.attr_file, self.conf3[m1 + '_parameter_dir'], mod_input_dir, '', self.run_type)
                 elif m1 == 'snow17':
-                    gfun.create_snow17_input(cat_mod, self.attr_file, self.gpkg_file, self.conf3[m2.replace("-", "_") + '_parameter_dir'], mod_input_dir)
+                    gfun.create_snow17_input(cat_mod, self.attr_file, self.conf3[m2.replace("-", "_") + '_parameter_dir'], mod_input_dir)
                 elif m1 == "pet":
                     gfun.create_pet_input(cat_mod, self.attr_file, mod_input_dir)
                 elif m1 == "sac":
@@ -1559,7 +1536,7 @@ class RealizationBuilder:
         self._parse_time()
         self._parse_reg_params()
         self._parse_reg_modules()
-        self._validate_reg_processes()
+        self._validate_processes()
         self._map_cat_to_grp()
         self._map_cat_to_form()
         self._map_mod_to_cat()

--- a/src/mswm/example_inputs/calibration/input_calibration.config
+++ b/src/mswm/example_inputs/calibration/input_calibration.config
@@ -183,9 +183,6 @@ lstm_parameter_dir = ~/ngwpc/nwm-cal-mgr/module_parameter_files/lstm
 sac_parameter_dir = ~/s3/ngwpc-hydrofabric
 snow_17_parameter_dir = ~/s3/ngwpc-hydrofabric
 
-# Path for model attributes file (to derive initial parameters for certain modules: CFE, NOM, SMP/SFT)
-attributes_file = ~/ngwpc/run_ngen/data/conus_model_attributes.parquet
-
 # Executable file for running ngen BMI
 ngen_exe_file = ~/ngwpc/ngen/cmake_build/ngen
 

--- a/src/mswm/example_inputs/default/input_default.config
+++ b/src/mswm/example_inputs/default/input_default.config
@@ -183,9 +183,6 @@ lstm_parameter_dir = ~/ngwpc/nwm-cal-mgr/module_parameter_files/lstm
 sac_parameter_dir = ~/s3/ngwpc-hydrofabric
 snow_17_parameter_dir = ~/s3/ngwpc-hydrofabric
 
-# Path for model attributes file (to derive initial parameters for certain modules: CFE, NOM, SMP/SFT)
-attributes_file = ~/ngwpc/run_ngen/data/conus_model_attributes.parquet
-
 # Executable file for running ngen BMI
 ngen_exe_file = ~/ngwpc/ngen/cmake_build/ngen
 

--- a/src/mswm/example_inputs/regionalization/input_regionalization.config
+++ b/src/mswm/example_inputs/regionalization/input_regionalization.config
@@ -183,9 +183,6 @@ lstm_parameter_dir = ~/ngwpc/nwm-cal-mgr/module_parameter_files/lstm
 sac_parameter_dir = ~/s3/ngwpc-hydrofabric
 snow_17_parameter_dir = ~/s3/ngwpc-hydrofabric
 
-# Path for model attributes file (to derive initial parameters for certain modules: CFE, NOM, SMP/SFT)
-attributes_file = ~/ngwpc/run_ngen/data/conus_model_attributes.parquet
-
 # Executable file for running ngen BMI
 ngen_exe_file = ~/ngwpc/ngen/cmake_build/ngen
 

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -785,10 +785,10 @@ def create_sft_smp_input(
                    'soil_moisture_bmi=1',
                    'end_time=1.[d]',
                    'dt=1.0[h]',
-                   'soil_params.smcmax=' + dfa.loc[catID]['mean.smcmax_soil_layers_stag=1'],
-                   'soil_params.b=' + dfa.loc[catID]['mode.bexp_soil_layers_stag=1'],
-                   'soil_params.satpsi=' + dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1'],
-                   'soil_params.quartz=' + dfa.loc[catID]['quartz'],
+                   'soil_params.smcmax=' + str(dfa.loc[catID]['mean.smcmax_soil_layers_stag=1']),
+                   'soil_params.b=' + str(dfa.loc[catID]['mode.bexp_soil_layers_stag=1']),
+                   'soil_params.satpsi=' + str(dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']),
+                   'soil_params.quartz=' + str(dfa.loc[catID]['quartz']),
                    'ice_fraction_scheme=' + icefscheme,
                    'soil_z=0.1,0.3,1.0,2.0[m]',
                    'soil_temperature=' + ','.join([str(mtemp)] * 4) + '[K]'
@@ -801,9 +801,9 @@ def create_sft_smp_input(
 
         # Create smp list
         smp_lst = ['verbosity=none',
-                   'soil_params.smcmax=' + dfa.loc[catID]['mean.smcmax_soil_layers_stag=1'],
-                   'soil_params.b=' + dfa.loc[catID]['mode.bexp_soil_layers_stag=1'],
-                   'soil_params.satpsi=' + dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1'],
+                   'soil_params.smcmax=' + str(dfa.loc[catID]['mean.smcmax_soil_layers_stag=1']),
+                   'soil_params.b=' + str(dfa.loc[catID]['mode.bexp_soil_layers_stag=1']),
+                   'soil_params.satpsi=' + str(dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']),
                    'soil_z=0.1,0.3,1.0,2.0[m]']
 
         if 'cfes' in mods or 'cfex' in mods:
@@ -1051,7 +1051,7 @@ def create_ueb_input(
 
 def create_sac_input(
         catids: List[str],
-        gpkg_file: Union[str, Path],
+        dfa: gpd.GeoDataFrame,
         param_dir_source: Union[str, Path],
         sac_input_dir: str
 ) -> None:
@@ -1060,7 +1060,7 @@ def create_sac_input(
     Parameters
     ----------
     catids : catchment IDs in the basin
-    gpkg_file: GeoPackage hydrofabric file
+    dfa: dataframe containing model parameter attributes
     param_dir_source : directory for sac parameter file
     sac_input_dir : directory for the sac bmi configuration file
 
@@ -1071,10 +1071,6 @@ def create_sac_input(
     """
     os.makedirs(sac_input_dir, exist_ok=True)
 
-    # Read geopackage divides
-    df_divide = gpd.read_file(gpkg_file, layer="divides")
-    df_divide.set_index('divide_id', inplace=True)
-
     # Read sac-sma parameter file
     param_filename = f'{param_dir_source}/sac_sma_params_2.2.csv'
     params_df = pd.read_csv(param_filename)
@@ -1084,7 +1080,7 @@ def create_sac_input(
 
         # Set catchment-specific sac-sma config parameters
         param_list = ['hru_id ' + catID,
-                      'hru_area ' + str(df_divide.loc[catID]['areasqkm']),
+                      'hru_area ' + str(dfa.loc[catID]['areasqkm']),
                       'uztwm ' + str(params_df.loc[catID]['UZTWM']),
                       'uzfwm ' + str(params_df.loc[catID]['UZFWM']),
                       'lztwm ' + str(params_df.loc[catID]['LZTWM']),
@@ -1357,10 +1353,8 @@ def change_lstm_input(
 def create_lstm_input(
         catids: List[str],
         dfa: gpd.GeoDataFrame,
-        gpkg_file: Union[str, Path],
         param_dir_source: Union[str, Path],
         lstm_input_dir: Union[str, Path],
-        xy_col: List[str]
 ) -> None:
 
     """
@@ -1369,10 +1363,9 @@ def create_lstm_input(
     ----------
     catids: catchment IDs in the basin
     dfa: dataframe containing model parameter attributes
-    gpkg_file: GeoPackage hydrofabric file
+    divides_layer: geodataframe containing hydrofabric divides layer
     param_dir_source: direcetory for static lstm files
     lstm_input_dir: target directory for bmi configuration file output (lstm_input)
-    xy_col: list of centroid column names in divivde-attributes file
 
     Returns
     ----------
@@ -1382,21 +1375,17 @@ def create_lstm_input(
     # Create input directory
     os.makedirs(lstm_input_dir, exist_ok=True)
 
-    # Read geopackage divides
-    df_divide = gpd.read_file(gpkg_file, layer="divides")
-    df_divide.set_index('divide_id', inplace=True)
-
     # Create static LSTM config yaml files
     create_lstm_config(param_dir_source, lstm_input_dir)
 
     # Create catchment specific LSTM bmi config files from scratch
     for catID in catids:
 
-        area = float(df_divide.loc[catID]['areasqkm'])
+        area = float(dfa.loc[catID]['areasqkm'])
         slope = float(dfa.loc[catID]['mean.slope'])
         elev = float(dfa.loc[catID]['mean.elevation'])
-        lat = float(dfa.loc[catID][xy_col[1]])
-        lon = float(dfa.loc[catID][xy_col[0]])
+        lat = float(dfa.loc[catID]['centroid_y'])
+        lon = float(dfa.loc[catID]['centroid_x'])
 
         namelist = {'area_sqkm': area,
                     'basin_id': catID,

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -793,7 +793,7 @@ def create_sft_smp_input(
                    'soil_params.satpsi=' + str(dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']),
                    'soil_params.quartz=' + str(dfa.loc[catID]['quartz']),
                    'ice_fraction_scheme=' + icefscheme,
-                   'soil_z=0.1,0.3hyd,1.0,2.0[m]',
+                   'soil_z=0.1,0.3,1.0,2.0[m]',
                    'soil_temperature=' + ','.join([str(mtemp)] * 4) + '[K]'
                    ]
 
@@ -807,7 +807,8 @@ def create_sft_smp_input(
                    'soil_params.smcmax=' + str(dfa.loc[catID]['mean.smcmax_soil_layers_stag=1']),
                    'soil_params.b=' + str(dfa.loc[catID]['mode.bexp_soil_layers_stag=1']),
                    'soil_params.satpsi=' + str(dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']),
-                   'soil_z=0.1,0.3,1.0,2.0[m]']
+                   'soil_z=0.1,0.3,1.0,2.0[m]',
+                   'soil_moisture_fraction_depth=0.4[m]']
 
         if 'cfes' in mods or 'cfex' in mods:
             smp_lst += ['soil_storage_model=conceptual', 'soil_storage_depth=2.0']

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -743,9 +743,7 @@ def create_noah_input_template(
 def create_sft_smp_input(
         catids: List[str],
         modules: Union[List[str], List[List[str]]],
-        attr_parquet: Union[str, Path],
         dfa: gpd.GeoDataFrame,
-        forcing_dir: Union[str, Path],
         sft_dir: Union[str, Path],
         smp_dir: Union[str, Path],
         run_type: str,
@@ -769,10 +767,6 @@ def create_sft_smp_input(
 
     os.makedirs(sft_dir, exist_ok=True)
     os.makedirs(smp_dir, exist_ok=True)
-
-    # Read hydrofabric attribute file
-    df_parquet = pd.read_parquet(attr_parquet)
-    df_parquet.set_index("divide_id", inplace=True)
 
     # Ice fraction scheme
     icefscheme = 'Schaake'

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -1394,7 +1394,7 @@ def create_lstm_input(
 
         area = float(df_divide.loc[catID]['areasqkm'])
         slope = float(dfa.loc[catID]['mean.slope'])
-        elev = float(dfa.loc[catID]['mean.elevation']) / 100
+        elev = float(dfa.loc[catID]['mean.elevation'])
         lat = float(dfa.loc[catID][xy_col[1]])
         lon = float(dfa.loc[catID][xy_col[0]])
 

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -398,15 +398,6 @@ def create_cfe_input(
         else:
             sft_coupled = '0'
 
-        # # TODO Temporary fix: set bexp value to very small value if it equals 0. Otherwise SMP raises an error
-        bexp_val = dfa.loc[catID]['mode.bexp_soil_layers_stag=1']
-        if bexp_val <= 0:
-            bexp_val = 0.001
-
-        satpsi_val = dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']
-        if satpsi_val <= 0:
-            satpsi_val = 0.001
-
         cfe_bmi_file = os.path.join(cfe_input_dir, catID + "_bmi_config_cfe.txt")
         f = open(cfe_bmi_file, "w")
         f.write("%s" % ("forcing_file=BMI\n"))
@@ -428,14 +419,12 @@ def create_cfe_input(
         f.write("%s" % ("max_gw_storage=" + str(dfa.loc[catID]['mean.Zmax'] / 1000.) + "[m]\n"))
         f.write("%s" % ("nash_storage=0.0,0.0[]\n"))
         f.write("%s" % ("refkdt=" + str(dfa.loc[catID]['mean.refkdt']) + "[]\n"))
-        # f.write("%s" % ("soil_params.b=" + str(dfa.loc[catID]['mode.bexp_soil_layers_stag=1']) + "[]\n"))
-        f.write("%s" % ("soil_params.b=" + str(bexp_val) + "[]\n"))
+        f.write("%s" % ("soil_params.b=" + str(dfa.loc[catID]['mode.bexp_soil_layers_stag=1']) + "[]\n"))
         f.write("%s" % ("soil_params.depth=2.0[m]\n"))
         f.write("%s" % ("soil_params.expon=1[]\n"))
         f.write("%s" % ("soil_params.expon_secondary=1[]\n"))
         f.write("%s" % ("soil_params.satdk=" + str(dfa.loc[catID]['geom_mean.dksat_soil_layers_stag=1']) + "[m/s]\n"))
-        # f.write("%s" % ("soil_params.satpsi=" + str(dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']) + "[m]\n"))
-        f.write("%s" % ("soil_params.satpsi=" + str(satpsi_val) + "[m]\n"))
+        f.write("%s" % ("soil_params.satpsi=" + str(dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']) + "[m]\n"))
         f.write("%s" % ("soil_params.slop=" + str(dfa.loc[catID]['mean.slope_1km']) + "[m/m]\n"))
         f.write("%s" % ("soil_params.smcmax=" + str(dfa.loc[catID]['mean.smcmax_soil_layers_stag=1']) + "[m/m]\n"))
         f.write("%s" % ("soil_params.wltsmc=" + str(dfa.loc[catID]['mean.smcwlt_soil_layers_stag=1']) + "[m/m]\n"))
@@ -2042,7 +2031,7 @@ def change_topmodel_input(
 def create_topmodel_input(
         catids: List[str],
         dfa: gpd.GeoDataFrame,
-        gpkg_file: Union[str, Path],
+        divides_layer: gpd.GeoDataFrame,
         inputDir: Union[str, Path],
 ) -> None:
     """ Create BMI configuration file for Topmodel
@@ -2051,7 +2040,7 @@ def create_topmodel_input(
     ----------
     catids : catchment IDs in the basin
     dfa: dataframe containing model parameter attributes
-    gpkg_file: GeoPackage hydrofabric file
+    divides_layer: geodataframe containing hydrofabric divides layer
     inputDir: directory for writing topmodel bmi configuration files
 
     Returns
@@ -2062,12 +2051,8 @@ def create_topmodel_input(
 
     os.makedirs(inputDir, exist_ok=True)
 
-    # Read geopackage divides file
-    df_divide = gpd.read_file(gpkg_file, layer="divides")
-    df_divide.set_index('divide_id', inplace=True)
-
     # Fill Nan lengthkm (coastal divides) with 0
-    df_divide['lengthkm'] = df_divide['lengthkm'].fillna(0)
+    divides_layer['lengthkm'] = divides_layer['lengthkm'].fillna(0)
 
     # Calculate median twi quartiles to fill missing values
     # Extract quartile twi values from divide-attributes
@@ -2108,7 +2093,7 @@ def create_topmodel_input(
 
         num_channels = 1
         cum_dist_area_with_dist = 1.0
-        dist_from_outlet = round(df_divide.loc[catID]['lengthkm'] * 1000)  # convert km to m
+        dist_from_outlet = round(divides_layer.loc[catID]['lengthkm'] * 1000)  # convert km to m
 
         # Format parameters for output
         subcat_line1 = f"{num_sub_catchments} {imap} {yes_print_output} \n"

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -17,7 +17,7 @@ import math
 from pathlib import Path
 from typing import List, Union, Dict
 from collections import OrderedDict
-
+from pyproj import Transformer
 import geopandas as gpd
 import pandas as pd
 import yaml
@@ -48,6 +48,7 @@ def is_probably_regex(pattern):
 
 
 __all__ = [
+    'change_hydrofab_attr',
     'create_walk_file',
     'create_cfe_input',
     'create_noah_input',
@@ -71,6 +72,162 @@ __all__ = [
     'create_calib_config_file',
     'create_partition_file',
 ]
+
+
+def change_hydrofab_attr(
+        vpu: str,
+        dfa: gpd.GeoDataFrame,
+        divides_layer: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    """ Set attribute names depending on geographic region and and adjust other hydrofabric values
+
+    Parameters
+    ----------
+    vpu: VPU identifier str of gage
+    dfa: dataframe containing model parameter attributes
+    divides_layer: geodataframe containing hydrofabric divides layer
+
+    Returns
+    ----------
+    dictionary of attribute names
+    """
+
+    # Set attr names
+    if vpu == 'hi' or vpu == 'ak':
+        attr_dict = {'X': 'centroid_x',
+                     'Y': 'centroid_y',
+                     'mode.bexp_soil_layers_stag.1': 'mode.bexp_soil_layers_stag=1',
+                     'mode.bexp_soil_layers_stag.2': 'mode.bexp_soil_layers_stag=2',
+                     'mode.bexp_soil_layers_stag.3': 'mode.bexp_soil_layers_stag=3',
+                     'mode.bexp_soil_layers_stag.4': 'mode.bexp_soil_layers_stag=4',
+                     'geom_mean.dksat_soil_layers_stag.1': 'geom_mean.dksat_soil_layers_stag=1',
+                     'geom_mean.dksat_soil_layers_stag.2': 'geom_mean.dksat_soil_layers_stag=2',
+                     'geom_mean.dksat_soil_layers_stag.3': 'geom_mean.dksat_soil_layers_stag=3',
+                     'geom_mean.dksat_soil_layers_stag.4': 'geom_mean.dksat_soil_layers_stag=4',
+                     'mean.smcmax_soil_layers_stag.1': 'mean.smcmax_soil_layers_stag=1',
+                     'mean.smcmax_soil_layers_stag.2': 'mean.smcmax_soil_layers_stag=2',
+                     'mean.smcmax_soil_layers_stag.3': 'mean.smcmax_soil_layers_stag=3',
+                     'mean.smcmax_soil_layers_stag.4': 'mean.smcmax_soil_layers_stag=4',
+                     'geom_mean.psisat_soil_layers_stag.1': 'geom_mean.psisat_soil_layers_stag=1',
+                     'geom_mean.psisat_soil_layers_stag.2': 'geom_mean.psisat_soil_layers_stag=2',
+                     'geom_mean.psisat_soil_layers_stag.3': 'geom_mean.psisat_soil_layers_stag=3',
+                     'geom_mean.psisat_soil_layers_stag.4': 'geom_mean.psisat_soil_layers_stag=4',
+                     'mean.smcwlt_soil_layers_stag.1': 'mean.smcwlt_soil_layers_stag=1',
+                     'mean.smcwlt_soil_layers_stag.2': 'mean.smcwlt_soil_layers_stag=2',
+                     'mean.smcwlt_soil_layers_stag.3': 'mean.smcwlt_soil_layers_stag=3',
+                     'mean.smcwlt_soil_layers_stag.4': 'mean.smcwlt_soil_layers_stag=4'}
+
+        logger.info('Setting hydrofabric attribute names to AK/HI region')
+
+    elif vpu == 'prvi':
+        attr_dict = {'dksat_Time._soil_layers_stag.1': 'geom_mean.dksat_soil_layers_stag=1',
+                     'dksat_Time._soil_layers_stag.2': 'geom_mean.dksat_soil_layers_stag=2',
+                     'dksat_Time._soil_layers_stag.3': 'geom_mean.dksat_soil_layers_stag=3',
+                     'dksat_Time._soil_layers_stag.4': 'geom_mean.dksat_soil_layers_stag=4',
+                     'mean.cwpvt_Time.': 'mean.cwpvt',
+                     'mean.mfsno_Time.': 'mean.mfsno',
+                     'mean.mp_Time.': 'mean.mp',
+                     'mean.refkdt_Time.': 'mean.refkdt',
+                     'mean.slope_Time.': 'mean.slope_1km',
+                     'mean.smcmax_Time._soil_layers_stag.1': 'mean.smcmax_soil_layers_stag=1',
+                     'mean.smcmax_Time._soil_layers_stag.2': 'mean.smcmax_soil_layers_stag=2',
+                     'mean.smcmax_Time._soil_layers_stag.3': 'mean.smcmax_soil_layers_stag=3',
+                     'mean.smcmax_Time._soil_layers_stag.4': 'mean.smcmax_soil_layers_stag=4',
+                     'mean.smcwlt_Time._soil_layers_stag.1': 'mean.smcwlt_soil_layers_stag=1',
+                     'mean.smcwlt_Time._soil_layers_stag.2': 'mean.smcwlt_soil_layers_stag=2',
+                     'mean.smcwlt_Time._soil_layers_stag.3': 'mean.smcwlt_soil_layers_stag=3',
+                     'mean.smcwlt_Time._soil_layers_stag.4': 'mean.smcwlt_soil_layers_stag=4',
+                     'mean.vcmx25_Time.': 'mean.vcmx25',
+                     'mode.bexp_Time._soil_layers_stag.1': 'mode.bexp_soil_layers_stag=1',
+                     'mode.bexp_Time._soil_layers_stag.2': 'mode.bexp_soil_layers_stag=2',
+                     'mode.bexp_Time._soil_layers_stag.3': 'mode.bexp_soil_layers_stag=3',
+                     'mode.bexp_Time._soil_layers_stag.4': 'mode.bexp_soil_layers_stag=4',
+                     'psisat_Time._soil_layers_stag.1': 'geom_mean.psisat_soil_layers_stag=1',
+                     'psisat_Time._soil_layers_stag.2': 'geom_mean.psisat_soil_layers_stag=2',
+                     'psisat_Time._soil_layers_stag.3': 'geom_mean.psisat_soil_layers_stag=3',
+                     'psisat_Time._soil_layers_stag.4': 'geom_mean.psisat_soil_layers_stag=4'}
+
+        logger.info('Setting hydrofabric attribute names to PRVI region')
+
+    elif vpu.isdigit():
+        # Leave hydrofabric attributes names as they are
+        logger.info('Setting hydrofabric attribute names to CONUS region')
+    else:
+        try:
+            raise Exception(f"Unregnized vpu in hydrofabric attriutes: {vpu}")
+        except Exception as e:
+            logger.critical(e)
+            raise
+
+    # Rename columns in attribute dataframe
+    if vpu == 'ak' or vpu == 'hi' or vpu == 'prvi':
+        dfa = dfa.rename(columns=attr_dict, inplace=True)
+
+    # Get catchement area from divides layer and append to attributes data frame
+    area = divides_layer[['divide_id', 'areasqkm']]
+    dfa = dfa.join(area.set_index('divide_id'), on='divide_id')
+
+    # Soil and vegetation types are read from the gpkg as floats, but need to be ints
+    dfa = dfa.astype({'mode.ISLTYP': 'int'})
+    dfa = dfa.astype({'mode.IVGTYP': 'int'})
+
+    # Adjust Zmax units from mm to m (CFE expects m)
+    dfa['mean.Zmax'] = dfa['mean.Zmax'].apply(lambda x: x / 1000)
+
+    # Convert elevation from cm to m. Except for AK, which is still in m.
+    if vpu != 'ak':
+        dfa['mean.elevation'] = dfa['mean.elevation'].apply(lambda x: x / 100)
+
+    # Convert centroid_x and centroid_y (lat/lon) from the domain's CRS to WGS84 for decimal degrees for 2.2.
+    crs = divides_layer.crs
+    transformer = Transformer.from_crs(crs, 4326)
+    for index, row in dfa.iterrows():
+        y = row['centroid_y']
+        x = row['centroid_x']
+        wgs84_latlon = transformer.transform(x, y)
+        dfa.loc[index, 'centroid_y'] = wgs84_latlon[0]  # latitude
+        dfa.loc[index, 'centroid_x'] = wgs84_latlon[1]  # longitude
+
+    # If a soil divide attribute less than the min value or greater than the max value, reset to min or max.
+    soil_attr = [{"name": "mode.bexp_soil_layers_stag=1", "min": 2, "max": 15},
+                 {"name": "geom_mean.dksat_soil_layers_stag=1", "min": 0.0000000195, "max": 0.000141},
+                 {"name": "geom_mean.psisat_soil_layers_stag=1", "min": 0.036, "max": 0.955},
+                 {"name": "mean.smcmax_soil_layers_stag=1", "min": 0.16, "max": 0.9},
+                 {"name": "mean.smcwlt_soil_layers_stag=1", "min": 0.05, "max": 0.30}]
+
+    for attr in soil_attr:
+        dfa.loc[dfa[attr['name']] > attr['max'], attr['name']] = attr['max']
+        dfa.loc[dfa[attr['name']] < attr['min'], attr['name']] = attr['min']
+
+    # Lookup quartz value by soil type as recommended in the Deltares spreadsheet.
+    # Quartz value by soil type source:  https://doi.org/10.1175/1520-0469(1998)055%3C1209:TEOSTC%3E2.0.CO;2
+    # Dictionary maps soil type (ISLTYP) to quartz value.
+    # Add a new column in the dataframe for quartz.
+    quartz_map = {1: 0.92,  # Sand
+                  2: 0.82,  # Loamy Sand
+                  3: 0.6,   # Sandy Loam
+                  4: 0.25,  # Silt Loam
+                  5: 0.1,  # Silt
+                  6: 0.4,  # Loam
+                  7: 0.6,  # Sandy Clay Loam
+                  8: 0.1,  # Silty Clay Loam
+                  9: 0.35,  # Clay Loam
+                  10: 0.52,  # Sandy Clay
+                  11: 0.1,  # Silty Clay
+                  12: 0.25,  # Clay
+                  13: 0,  # Organic Material,
+                  14: 0,  # Water
+                  15: 0,  # Bedrock
+                  16: 0,  # Other
+                  17: 0,  # Playa
+                  18: 0,  # Lava
+                  19: 0,  # White Sand
+                  }
+
+    dfa['quartz'] = dfa['mode.ISLTYP'].map(quartz_map)
+
+    # Return updated attributes
+    return dfa
 
 
 def create_walk_file(
@@ -186,7 +343,7 @@ def create_walk_file(
 def create_cfe_input(
         catids: List[str],
         modules: Union[List[str], List[List[str]]],
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         cfe_input_dir: Union[str, Path],
         run_type: str,
         is_aet_rootzone: Union[int, dict]
@@ -364,7 +521,7 @@ def change_cfe_input(
 def create_noah_input(
         catids: List[str],
         time_period: dict,
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         param_dir_source: Union[str, Path],
         noah_input_dir: Union[str, Path],
         run_type: str
@@ -684,7 +841,7 @@ def create_sft_smp_input(
 
 def create_snow17_input(
         catids: List[str],
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         gpkg_file: Union[str, Path],
         param_dir_source: Union[str, Path],
         snow17_input_dir: str
@@ -788,7 +945,7 @@ def create_snow17_input(
 def create_ueb_input(
         catids: List[str],
         time_period: dict,
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         param_dir_source: Union[str, Path],
         ueb_input_dir: str,
         bmi_dir: Union[str, Path],
@@ -1224,7 +1381,7 @@ def change_lstm_input(
 
 def create_lstm_input(
         catids: List[str],
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         gpkg_file: Union[str, Path],
         param_dir_source: Union[str, Path],
         lstm_input_dir: Union[str, Path],
@@ -1383,7 +1540,7 @@ def change_sac_snow17_input(
 
 def create_pet_input(
         catids: List[str],
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         pet_input_dir: str
 ) -> None:
     """ Create BMI configuration file for pet
@@ -1436,7 +1593,7 @@ def create_pet_input(
 def create_lasam_input(
         catids: List[str],
         modules: Union[List[str], List[List[str]]],
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         input_dir: Union[str, Path],
         param_dir: Union[str, Path],
         run_type: str
@@ -1899,7 +2056,7 @@ def change_topmodel_input(
 
 def create_topmodel_input(
         catids: List[str],
-        dfa: Union[str, Path],
+        dfa: pd.DataFrame,
         gpkg_file: Union[str, Path],
         inputDir: Union[str, Path],
 ) -> None:

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -793,7 +793,7 @@ def create_sft_smp_input(
                    'soil_params.satpsi=' + str(dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1']),
                    'soil_params.quartz=' + str(dfa.loc[catID]['quartz']),
                    'ice_fraction_scheme=' + icefscheme,
-                   'soil_z=0.1,0.3,1.0,2.0[m]',
+                   'soil_z=0.1,0.3hyd,1.0,2.0[m]',
                    'soil_temperature=' + ','.join([str(mtemp)] * 4) + '[K]'
                    ]
 
@@ -1621,13 +1621,14 @@ def create_lasam_input(
                  'ponded_depth_max=1.1[cm]',
                  'use_closed_form_G=false',
                  'layer_soil_type=',
-                 'max_soil_types=18',
+                 'max_soil_types=15',
                  'wilting_point_psi=15495.0[cm]',
-                 'giuh_ordinates=0.55,0.25,0.2',  # Where should this be supplied from?
-                 'sft_coupled=',
-                 'soil_z=10,30,100.0,200.0[cm]',
-                 'calib_params=true',
                  'field_capacity_psi=340.9[cm]',
+                 'giuh_ordinates=0.06,0.51,0.28,0.12,0.03',
+                 'calib_params=true',
+                 'adaptive_timestep=true',
+                 'sft_coupled=',
+                 'soil_z=10,30,100.0,200.0[cm]'
                  ]
 
     # Set module list for non-regionalization run
@@ -1648,9 +1649,8 @@ def create_lasam_input(
 
         # Check if sft is in use
         sft_coupled_str = 'true' if 'sft' in mods else 'false'
-        lasam_lst_catID[13] = 'sft_coupled=' + sft_coupled_str
+        lasam_lst_catID[16] += sft_coupled_str
 
-        # lasam_lst_catID[12] = lasam_lst_catID[12] + df.loc['giuh_ordinates'][0]
         lasam_bmi_file = os.path.join(input_dir, catID + '_bmi_config_lasam.txt')
 
         with open(lasam_bmi_file, "w") as f:

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -6,7 +6,6 @@ This module contains a variety of functions to create different input files.
 
 import copy
 import datetime
-import fnmatch
 import glob
 import json
 import os
@@ -343,7 +342,7 @@ def create_walk_file(
 def create_cfe_input(
         catids: List[str],
         modules: Union[List[str], List[List[str]]],
-        dfa: pd.DataFrame,
+        dfa: gpd.GeoDataFrame,
         cfe_input_dir: Union[str, Path],
         run_type: str,
         is_aet_rootzone: Union[int, dict]
@@ -521,7 +520,7 @@ def change_cfe_input(
 def create_noah_input(
         catids: List[str],
         time_period: dict,
-        dfa: pd.DataFrame,
+        dfa: gpd.GeoDataFrame,
         param_dir_source: Union[str, Path],
         noah_input_dir: Union[str, Path],
         run_type: str
@@ -745,7 +744,7 @@ def create_sft_smp_input(
         catids: List[str],
         modules: Union[List[str], List[List[str]]],
         attr_parquet: Union[str, Path],
-        cfe_dir: Union[str, Path],
+        dfa: gpd.GeoDataFrame,
         forcing_dir: Union[str, Path],
         sft_dir: Union[str, Path],
         smp_dir: Union[str, Path],
@@ -757,9 +756,7 @@ def create_sft_smp_input(
     ----------
     catids : catchment IDs in the basin
     modules: list of modules in the formulation
-    attr_parquet: parquet file containing model attributes
-    cfe_dir : directory containing cfe bmi configuration files
-    forcing_dir : directory containing forcing files
+    dfa: dataframe containing model parameter attributes
     sft_dir : directory for writing sft bmi configuration files
     smp_dir : directory for writing smp bmi configuration files
     run_type: type of run (calib, regionalization, or default)
@@ -789,51 +786,50 @@ def create_sft_smp_input(
 
         catID = catids[i]
 
-        # Check if catID is in parquet file (some catchments are missing). This will eventually be replaced when parquet file is not needed for quartz values
-        # Set soil_params.quartz value
-        if catID in df_parquet.index:
-            quartz_val = str(df_parquet.loc[catID][[x for x in df_parquet.columns.to_list() if 'quartz' in x]].mean()) + '[]'  # soil_params.quartz not available in divide-attributes
-        else:
-            quartz_val = '0[]'
-
         # Set module list for each catchment during regionalization
         if run_type == 'regionalization':
             mods = modules[i]
             if ('cfex' in mods):
                 icefscheme = 'Xinanjiang'
 
-        # Read cfe BMI files
-        cfe_bmi_file = os.path.join(cfe_dir, fnmatch.filter(os.listdir(cfe_dir), '*' + catID + '*.txt')[0])
-        df = pd.read_table(cfe_bmi_file, delimiter='=', names=["Params", "Values"], index_col=0)
-
         # Obtain annual mean surface temperature as proxy for initial soil temperature
-        fdf = pd.read_table(os.path.join(forcing_dir, catID + '.csv'), delimiter=',')
-        mtemp = round(fdf['T2D'].mean(), 2)
+        # This value is just a reasonable estimate per new direction (Edwin)
+        mtemp = (45 - 32) * 5 / 9 + 273.15  # this is avg soil temp of 45 degrees F converted to Kelvin
 
         # Create sft list
-        sft_lst = ['verbosity=none', 'soil_moisture_bmi=1', 'end_time=1.[d]', 'dt=1.0[h]',
-                   'soil_params.smcmax=' + df.loc['soil_params.smcmax'].iloc[0],
-                   'soil_params.b=' + df.loc['soil_params.b'].iloc[0],
-                   'soil_params.satpsi=' + df.loc['soil_params.satpsi'].iloc[0],
-                   'soil_params.quartz=' + quartz_val,
+        sft_lst = ['verbosity=none',
+                   'soil_moisture_bmi=1',
+                   'end_time=1.[d]',
+                   'dt=1.0[h]',
+                   'soil_params.smcmax=' + dfa.loc[catID]['mean.smcmax_soil_layers_stag=1'],
+                   'soil_params.b=' + dfa.loc[catID]['mode.bexp_soil_layers_stag=1'],
+                   'soil_params.satpsi=' + dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1'],
+                   'soil_params.quartz=' + dfa.loc[catID]['quartz'],
                    'ice_fraction_scheme=' + icefscheme,
                    'soil_z=0.1,0.3,1.0,2.0[m]',
                    'soil_temperature=' + ','.join([str(mtemp)] * 4) + '[K]'
                    ]
+
+        # Write sft config to file
         sft_bmi_file = os.path.join(sft_dir, catID + '_bmi_config_sft.txt')
         with open(sft_bmi_file, "w") as f:
             f.writelines('\n'.join(sft_lst))
 
         # Create smp list
         smp_lst = ['verbosity=none',
-                   'soil_params.smcmax=' + df.loc['soil_params.smcmax'].iloc[0],
-                   'soil_params.b=' + df.loc['soil_params.b'].iloc[0],
-                   'soil_params.satpsi=' + df.loc['soil_params.satpsi'].iloc[0],
+                   'soil_params.smcmax=' + dfa.loc[catID]['mean.smcmax_soil_layers_stag=1'],
+                   'soil_params.b=' + dfa.loc[catID]['mode.bexp_soil_layers_stag=1'],
+                   'soil_params.satpsi=' + dfa.loc[catID]['geom_mean.psisat_soil_layers_stag=1'],
                    'soil_z=0.1,0.3,1.0,2.0[m]']
+
         if 'cfes' in mods or 'cfex' in mods:
             smp_lst += ['soil_storage_model=conceptual', 'soil_storage_depth=2.0']
+        elif 'topmodel' in mods:
+            smp_lst += ['soil_storage_model=TopModel', 'water_table_based_method=flux-based']
         elif 'lasam' in mods:
             smp_lst += ['soil_storage_model=layered', 'soil_moisture_profile_option=constant', 'soil_depth_layers=2.0', 'water_table_depth=10[m]']
+
+        # Write smp to to file
         smp_bmi_file = os.path.join(smp_dir, catID + '_bmi_config_smp.txt')
         with open(smp_bmi_file, "w") as f:
             f.writelines('\n'.join(smp_lst))
@@ -841,8 +837,7 @@ def create_sft_smp_input(
 
 def create_snow17_input(
         catids: List[str],
-        dfa: pd.DataFrame,
-        gpkg_file: Union[str, Path],
+        dfa: gpd.GeoDataFrame,
         param_dir_source: Union[str, Path],
         snow17_input_dir: str
 ) -> None:
@@ -863,10 +858,6 @@ def create_snow17_input(
    """
     os.makedirs(snow17_input_dir, exist_ok=True)
 
-    # Read geopackage divides
-    df_divide = gpd.read_file(gpkg_file, layer="divides")
-    df_divide.set_index('divide_id', inplace=True)
-
     # Read snow17 parameter file
     param_filename = f'{param_dir_source}/snow17_params_2.2.csv'
     params_df = pd.read_csv(param_filename)
@@ -876,7 +867,7 @@ def create_snow17_input(
 
         # Set catchment-specific snow17 config parameters
         param_list = ['hru_id ' + catID,
-                      'hru_area ' + str(df_divide.loc[catID]['areasqkm']),
+                      'hru_area ' + str(dfa.loc[catID]['areasqkm']),
                       'latitude ' + str(dfa.loc[catID].geometry.y),
                       'elev ' + str(dfa.loc[catID]['mean.elevation']),
                       'scf 1.100',
@@ -945,7 +936,7 @@ def create_snow17_input(
 def create_ueb_input(
         catids: List[str],
         time_period: dict,
-        dfa: pd.DataFrame,
+        dfa: gpd.GeoDataFrame,
         param_dir_source: Union[str, Path],
         ueb_input_dir: str,
         bmi_dir: Union[str, Path],
@@ -1381,7 +1372,7 @@ def change_lstm_input(
 
 def create_lstm_input(
         catids: List[str],
-        dfa: pd.DataFrame,
+        dfa: gpd.GeoDataFrame,
         gpkg_file: Union[str, Path],
         param_dir_source: Union[str, Path],
         lstm_input_dir: Union[str, Path],
@@ -1540,7 +1531,7 @@ def change_sac_snow17_input(
 
 def create_pet_input(
         catids: List[str],
-        dfa: pd.DataFrame,
+        dfa: gpd.GeoDataFrame,
         pet_input_dir: str
 ) -> None:
     """ Create BMI configuration file for pet
@@ -1593,7 +1584,7 @@ def create_pet_input(
 def create_lasam_input(
         catids: List[str],
         modules: Union[List[str], List[List[str]]],
-        dfa: pd.DataFrame,
+        dfa: gpd.GeoDataFrame,
         input_dir: Union[str, Path],
         param_dir: Union[str, Path],
         run_type: str
@@ -2056,7 +2047,7 @@ def change_topmodel_input(
 
 def create_topmodel_input(
         catids: List[str],
-        dfa: pd.DataFrame,
+        dfa: gpd.GeoDataFrame,
         gpkg_file: Union[str, Path],
         inputDir: Union[str, Path],
 ) -> None:

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -163,9 +163,12 @@ def change_hydrofab_attr(
     if vpu == 'ak' or vpu == 'hi' or vpu == 'prvi':
         dfa = dfa.rename(columns=attr_dict, inplace=True)
 
-    # Get catchement area from divides layer and append to attributes data frame
-    area = divides_layer[['divide_id', 'areasqkm']]
-    dfa = dfa.join(area.set_index('divide_id'), on='divide_id')
+    # Get catchment area from divides layer and append to attributes data frame
+    divide_vals = divides_layer[['divide_id', 'lengthkm', 'areasqkm']]
+    dfa = dfa.join(divide_vals.set_index('divide_id'), on='divide_id')
+
+    # Fill Nan lengthkm (coastal divides) with 0
+    dfa['lengthkm'] = dfa['lengthkm'].fillna(0)
 
     # Soil and vegetation types are read from the gpkg as floats, but need to be ints
     dfa = dfa.astype({'mode.ISLTYP': 'int'})
@@ -2021,7 +2024,6 @@ def change_topmodel_input(
 def create_topmodel_input(
         catids: List[str],
         dfa: gpd.GeoDataFrame,
-        divides_layer: gpd.GeoDataFrame,
         inputDir: Union[str, Path],
 ) -> None:
     """ Create BMI configuration file for Topmodel
@@ -2030,7 +2032,6 @@ def create_topmodel_input(
     ----------
     catids : catchment IDs in the basin
     dfa: dataframe containing model parameter attributes
-    divides_layer: geodataframe containing hydrofabric divides layer
     inputDir: directory for writing topmodel bmi configuration files
 
     Returns
@@ -2040,9 +2041,6 @@ def create_topmodel_input(
     """
 
     os.makedirs(inputDir, exist_ok=True)
-
-    # Fill Nan lengthkm (coastal divides) with 0
-    divides_layer['lengthkm'] = divides_layer['lengthkm'].fillna(0)
 
     # Calculate median twi quartiles to fill missing values
     # Extract quartile twi values from divide-attributes
@@ -2083,7 +2081,7 @@ def create_topmodel_input(
 
         num_channels = 1
         cum_dist_area_with_dist = 1.0
-        dist_from_outlet = round(divides_layer.loc[catID]['lengthkm'] * 1000)  # convert km to m
+        dist_from_outlet = round(dfa.loc[catID]['lengthkm'] * 1000)  # convert km to m
 
         # Format parameters for output
         subcat_line1 = f"{num_sub_catchments} {imap} {yes_print_output} \n"

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -74,7 +74,6 @@ __all__ = [
 
 
 def change_hydrofab_attr(
-        vpu: str,
         dfa: gpd.GeoDataFrame,
         divides_layer: gpd.GeoDataFrame
 ) -> gpd.GeoDataFrame:
@@ -82,7 +81,6 @@ def change_hydrofab_attr(
 
     Parameters
     ----------
-    vpu: VPU identifier str of gage
     dfa: dataframe containing model parameter attributes
     divides_layer: geodataframe containing hydrofabric divides layer
 
@@ -90,6 +88,9 @@ def change_hydrofab_attr(
     ----------
     dictionary of attribute names
     """
+
+    # Retrieve vpu id from dfa
+    vpu = dfa['vpuid'].mode()[0]
 
     # Set attr names
     if vpu == 'hi' or vpu == 'ak':

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -571,8 +571,8 @@ def create_noah_input(
             for catID in catids:
                 tslp = dfa.loc[catID]['mean.slope']
                 azimuth = dfa.loc[catID]['circ_mean.aspect']
-                lat = dfa.loc[catID].geometry.y
-                lon = dfa.loc[catID].geometry.x
+                lat = dfa.loc[catID]['centroid_y']
+                lon = dfa.loc[catID]['centroid_x']
                 isltype = int(dfa.loc[catID]["mode.ISLTYP"])
                 vegtype = int(dfa.loc[catID]["mode.IVGTYP"])
                 sfctype = 2 if vegtype == 16 else 1
@@ -862,7 +862,7 @@ def create_snow17_input(
         # Set catchment-specific snow17 config parameters
         param_list = ['hru_id ' + catID,
                       'hru_area ' + str(dfa.loc[catID]['areasqkm']),
-                      'latitude ' + str(dfa.loc[catID].geometry.y),
+                      'latitude ' + str(dfa.loc[catID]['centroid_y']),
                       'elev ' + str(dfa.loc[catID]['mean.elevation']),
                       'scf 1.100',
                       'mfmax ' + str(params_df.loc[catID]['MFMAX']),
@@ -1006,8 +1006,8 @@ def create_ueb_input(
             # retrieve slope, aspect, lat and lon from precomputed attributes file
             tslp = dfa.loc[catID]['mean.slope']
             azimuth = dfa.loc[catID]['circ_mean.aspect']
-            lat = dfa.loc[catID].geometry.y
-            lon = dfa.loc[catID].geometry.x
+            lat = dfa.loc[catID]['centroid_y']
+            lon = dfa.loc[catID]['centroid_x']
 
             temp_file = Path(param_dir_source, 'ueb_sitevars.dat').resolve(strict=True)
             with open(temp_file) as f:
@@ -1561,8 +1561,8 @@ def create_pet_input(
                     'surface_longwave_emissivity=1.0',
                     'surface_shortwave_albedo=0.22',
                     'cloud_base_height_known=FALSE',
-                    'latitude_degrees=' + str(dfa.loc[catID].geometry.y),
-                    'longitude_degrees=' + str(dfa.loc[catID].geometry.x),
+                    'latitude_degrees=' + str(dfa.loc[catID]['centroid_y']),
+                    'longitude_degrees=' + str(dfa.loc[catID]['centroid_x']),
                     'site_elevation_m=' + str(dfa.loc[catID]['mean.elevation']),
                     'time_step_size_s=3600',
                     'num_timesteps=720',  # This needs to be set from the input files, possibly for calib and valid

--- a/src/mswm/utils/input_configuration.py
+++ b/src/mswm/utils/input_configuration.py
@@ -217,7 +217,7 @@ class DataFileConfig(StrictBaseModel):
     lstm_parameter_dir: Optional[str] = None
     sac_parameter_dir: Optional[str] = None
     snow_17_parameter_dir: Optional[str] = None
-    attributes_file: str
+    attributes_file: Optional[str] = None
     ngen_exe_file: str
     sloth_lib: Optional[str] = None
     cfe_lib: Optional[str] = None


### PR DESCRIPTION
Made several updates to msw-mgr to match recent EDFS updates to handling of bmi config files in the hydrofabric API. 
The following changes only impact the generation of bmi config files when EDFS config files are not provided. These changes should have no effect on the server/UI. The changes include:

- Added support for different hydrofabric attribute names between CONUS, PR, AK, and HI.
- Updated handling of soil attributes and quartz value to match changes in EDFS API
- Added minor unit fixes to Zmax and elevation variables
- Refactored SFT/SMP config creation to not rely on CFE config files
- Combined validation_processes for single basin and regionalization runs into single function to avoid repitition
- Deprecated use of CONUS parquet file in msw-mgr, all variables retrieved from attributes layer in hydrofabric