### PR TITLE
Pydantic fix for regionalization variables

### DIFF
--- a/src/mswm/utils/input_configuration.py
+++ b/src/mswm/utils/input_configuration.py
@@ -73,8 +73,8 @@ class RegionConfig(StrictBaseModel):
     """
     Input.config regionalization section requirement
     """
-    form_assign_file: str
-    cat_grp_file: str
+    form_assign_file: Optional[str] = None
+    cat_grp_file: Optional[str] = None
 
 
 class CalibConfig(StrictBaseModel):


### PR DESCRIPTION
Minor bug introduced with forecast_validation_root_dir merge. Ensured that regionalization variables could be left blank in input.config for non-regionalization runs.