### PR TITLE
Remove extra hour at end of cold start

### DIFF
--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -2532,7 +2532,7 @@ def create_fcst_times(
     if use_cold_start is True:
 
         fcst_start = cold_start_datetime
-        fcst_end = datetime.datetime.strftime(cycle_dt + datetime.timedelta(hours=1), "%Y-%m-%d %H:%M:%S")
+        fcst_end = datetime.datetime.strftime(cycle_dt, "%Y-%m-%d %H:%M:%S")
 
     # Construct start and end times based on forecast cycle
     elif ana_flag == 0:


### PR DESCRIPTION
Remove extra hour added to the end of cold start period when setting run end time in realization. Change needed due to other updates in ngen-forcing.