### PR TITLE
Removed check for isdigit vpu id

### DIFF
--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -166,15 +166,9 @@ def change_hydrofab_attr(
 
         logger.info('Setting hydrofabric attribute names to PRVI region')
 
-    elif vpu.isdigit():
+    else:
         # Leave hydrofabric attributes names as they are
         logger.info('Setting hydrofabric attribute names to CONUS region')
-    else:
-        try:
-            raise Exception(f"Unregnized vpu in hydrofabric attriutes: {vpu}")
-        except Exception as e:
-            logger.critical(e)
-            raise
 
     # Rename columns in attribute dataframe
     if vpu == 'ak' or vpu == 'hi' or vpu == 'prvi':


### PR DESCRIPTION
Removed check for unrecognized VPU id str. Sometimes, the VPU id can be in the form of '03S', which fails the isdigit check.