### PR TITLE
Fix typo in sloth if statement

### DIFF
--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -3458,7 +3458,7 @@ def create_realization_file(
                     "Qb_topmodel(1,double,m h^-1,node)": 0.0,
                     "Qv_topmodel(1,double,m h^-1,node)": 0.0,
                     "global_deficit(1,double,m,node)": 0.0}
-        elif 'topmodel' and 'smp' in modules:
+        elif 'topmodel' in modules and 'smp' in modules:
             model_params = {
                 "sloth_soil_storage(1,double,m,node)": 1.0E-10,
                 "sloth_soil_storage_change(1,double,m,node)": 0.0,


### PR DESCRIPTION
Richard raised an error in https://jira.nextgenwaterprediction.com/browse/NGWPC-8801 relating to SMP-LASAM formulations. I fixed an error in an if statement in the realization file logic that caused the wrong variable name mappings to be used in SLOTH.