### PR TITLE
Update pyproject.toml with module parameter files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,11 @@ dependencies = [
 ]
 
 [tool.setuptools]
+include-package-data = true
 package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"mswm.module_parameter_files" = ["**/*"]


### PR DESCRIPTION
Modified pyporject.toml to include module_parameter_files when installing msw-mgr as a package.