### PR TITLE
Jwade lstm var names

### DIFF
--- a/src/mswm/build_inputs.py
+++ b/src/mswm/build_inputs.py
@@ -845,7 +845,6 @@ class RealizationBuilder:
             except Exception as e:
                 logger.error(f"Failed to remove existing {self.cat_file}: {e}")
                 raise
-            
 
         try:
             os.symlink(self.gpkg_file, self.cat_file)
@@ -1124,7 +1123,6 @@ class RealizationBuilder:
                         except OSError as e:
                             logger.critical(f"Failed to create symlink: {bmi_dir} -> {mod_input_dir}: {e}")
                             raise
-                        
 
             else:
                 # Create BMI config files from scratch if paths not provided
@@ -1258,6 +1256,17 @@ class RealizationBuilder:
                                                                                      self.output_dict['sm_frac_depth'], self.output_dict['sm_profile_depth'])
                     # Modify existing SFT inputs to match rainfall runoff model
                     elif m1 == "sft":
+                        # Loop through schemes that could be paired with SFT (CFES/CFEX/LASAM)
+                        # SFT could be paired with CFES/CFEX/LASAM simulatenously in different formulations, so configs must be generated separately
+                        for scheme in ['cfes', 'cfex', 'lasam', 'topmodel']:
+                            # Retrieve formulation groups where CFES/CFEX/LASAM co-occur with SFT
+                            scheme_sft_grps = [grp for grp, mods in self.grp_to_form.items() if scheme in mods and 'sft' in mods]
+
+                            if scheme_sft_grps:
+                                # Retrieve catchments and formulations corresponding to scheme
+                                scheme_cat = [cat for grp in scheme_sft_grps for cat in self.grp_to_cat[grp]]
+                                scheme_form = [self.cat_to_form[cat] for cat in scheme_cat]
+
                         # Create SFT inputs
                         gfun.change_sft_input(scheme_cat, scheme_form, mod_input_dir, bmi_dir, self.run_type)
 
@@ -1271,21 +1280,20 @@ class RealizationBuilder:
                             file_match = list(Path(bmi_dir).glob(f"*{cat}*"))
                             for fp in file_match:
                                 dest = Path(mod_input_dir) / fp.name
-                                
+
                                 if os.path.exists(dest) or os.path.islink(dest):
                                     try:
                                         dest.unlink()
                                     except Exception as e:
                                         logger.error(f"Failed to remove existing {dest}: {e}")
                                         raise
-                                    
+
                                 try:
                                     os.symlink(fp.resolve(), dest)
                                 except OSError as e:
                                     logger.critical(f"Failed to create symlink: {fp} -> {dest}: {e}")
                                     raise
                         logger.info(f'{m2}: create symlink from {bmi_dir} to {mod_input_dir}')
-                                
 
             else:
                 # Create BMI config files from scratch if paths not provided

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -3622,9 +3622,9 @@ def create_realization_file(
         # variable name mapping section
         variables_names_map = dict()
         variables_names_map["streamflow_cms"] = "land_surface_water__runoff_volume_flux",
-        variables_names_map["pytorch_model_path"] = os.path.join(bmi_dir['lstm'], "sugar_creek_trained.pt"),
-        variables_names_map["normalization_path"] = os.path.join(bmi_dir['lstm'], "input_scaling.csv"),
-        variables_names_map["initial_state_path"] = os.path.join(bmi_dir['lstm'], "initial_states.csv"),
+        variables_names_map["pytorch_model_path"] = os.path.join(bmi_dir['lstm'], "sugar_creek_trained.pt")
+        variables_names_map["normalization_path"] = os.path.join(bmi_dir['lstm'], "input_scaling.csv")
+        variables_names_map["initial_state_path"] = os.path.join(bmi_dir['lstm'], "initial_states.csv")
         variables_names_map["useGPU"] = False
 
         var_maps = dict()

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -3198,10 +3198,10 @@ def create_reg_realization_file(
 
             # variable name mapping section
             variables_names_map = dict()
-            variables_names_map["streamflow_cms"] = "land_surface_water__runoff_volume_flux",
-            variables_names_map["pytorch_model_path"] = os.path.join(bmi_dir['lstm'], "sugar_creek_trained.pt"),
-            variables_names_map["normalization_path"] = os.path.join(bmi_dir['lstm'], "input_scaling.csv"),
-            variables_names_map["initial_state_path"] = os.path.join(bmi_dir['lstm'], "initial_states.csv"),
+            variables_names_map["streamflow_cms"] = "land_surface_water__runoff_volume_flux"
+            variables_names_map["pytorch_model_path"] = os.path.join(bmi_dir['lstm'], "sugar_creek_trained.pt")
+            variables_names_map["normalization_path"] = os.path.join(bmi_dir['lstm'], "input_scaling.csv")
+            variables_names_map["initial_state_path"] = os.path.join(bmi_dir['lstm'], "initial_states.csv")
             variables_names_map["useGPU"] = False
 
             var_maps = dict()

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -3621,7 +3621,7 @@ def create_realization_file(
 
         # variable name mapping section
         variables_names_map = dict()
-        variables_names_map["streamflow_cms"] = "land_surface_water__runoff_volume_flux",
+        variables_names_map["streamflow_cms"] = "land_surface_water__runoff_volume_flux"
         variables_names_map["pytorch_model_path"] = os.path.join(bmi_dir['lstm'], "sugar_creek_trained.pt")
         variables_names_map["normalization_path"] = os.path.join(bmi_dir['lstm'], "input_scaling.csv")
         variables_names_map["initial_state_path"] = os.path.join(bmi_dir['lstm'], "initial_states.csv")

--- a/src/mswm/utils/ginputfunc.py
+++ b/src/mswm/utils/ginputfunc.py
@@ -1531,7 +1531,7 @@ def change_sac_snow17_input(
                 os.symlink(param_file0, param_file)
             except OSError as e:
                 logger.critical(f"Failed to create symlink: {param_file0} -> {param_file}: {e}")
-                raise 
+                raise
         else:
             try:
                 raise Exception(f'Parameter file does not exist: {param_file0}')
@@ -3160,12 +3160,11 @@ def create_reg_realization_file(
                     "num_wetting_fronts": "soil_num_wetting_fronts"}
             elif 'topmodel' in grp_mod:
                 model_configs['smp']['params']["variables_names_map"] = {
-                    "soil_storage" : "sloth_soil_storage",
-                    "soil_storage_change" : "sloth_soil_storage_change",
-                    "Qb_topmodel" : "land_surface_water__baseflow_volume_flux",
-                    "Qv_topmodel" : "soil_water_root-zone_unsat-zone_top__recharge_volume_flux",
-                    "global_deficit" : "soil_water__domain_volume_deficit"}
-
+                    "soil_storage": "sloth_soil_storage",
+                    "soil_storage_change": "sloth_soil_storage_change",
+                    "Qb_topmodel": "land_surface_water__baseflow_volume_flux",
+                    "Qv_topmodel": "soil_water_root-zone_unsat-zone_top__recharge_volume_flux",
+                    "global_deficit": "soil_water__domain_volume_deficit"}
 
         # lasam
         if 'lasam' in grp_mod:
@@ -3349,7 +3348,6 @@ def create_realization_file(
         except OSError as e:
             logger.critical(f"Failed to create symlink: {value} -> {lib_mod_link}: {e}")
             raise
-
 
     model_configs = {}
 
@@ -3587,11 +3585,11 @@ def create_realization_file(
                 "num_wetting_fronts": "soil_num_wetting_fronts"}
         elif 'topmodel' in modules:
             model_configs['smp']['params']["variables_names_map"] = {
-                "soil_storage" : "sloth_soil_storage",
-				"soil_storage_change" : "sloth_soil_storage_change",
-				"Qb_topmodel" : "land_surface_water__baseflow_volume_flux",
-				"Qv_topmodel" : "soil_water_root-zone_unsat-zone_top__recharge_volume_flux",
-				"global_deficit" : "soil_water__domain_volume_deficit"}
+                "soil_storage": "sloth_soil_storage",
+                "soil_storage_change": "sloth_soil_storage_change",
+                "Qb_topmodel": "land_surface_water__baseflow_volume_flux",
+                "Qv_topmodel": "soil_water_root-zone_unsat-zone_top__recharge_volume_flux",
+                "global_deficit": "soil_water__domain_volume_deficit"}
 
     # lasam
     if 'lasam' in modules:


### PR DESCRIPTION
Updated LSTM realization file logic to match format of other modules. Previously, each individual variable in the name mapping was being stored as a list, which caused an error to occur when attempting to create forecast inputs for an LSTM formulation.

I also added back some missing code for SFT for regionalization, which was mistakenly deleted.