### PR TITLE
Upgrade shapely from 1 to 2, match ngen-forcing pins for other dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "fiona~=1.10.1",                # Match ngen-forcing
   "pyproj>=3.2.0,<4.0.0",         # Match ngen-forcing
   "pandas~=2.3.3",                # Match ngen-forcing
-  "netCDF4~=1.6.3",               # Match ngen-forcing
+  "netCDF4==1.6.3",               # Match ngen-forcing
   "pydantic~=2.11.9",
   "PyYAML~=6.0.2",                # Match ngen-forcing
   "numpy~=1.26.4",                # Match ngen-forcing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,15 @@ name = "mswm"
 version = "0.1.1"           # or mark as dynamic if you use setuptools-scm
 requires-python = ">=3.11"
 dependencies = [
-  "geopandas>=0.11.0,<0.14.0",
-  "shapely>=1.8.0,<2.0.0",        # CRITICAL - must be <2.0!
-  "fiona>=1.8.0,<1.10.0",         # Must match ngen-forcing
-  "pyproj>=3.2.0,<4.0.0",         # Must match ngen-forcing
-  "pandas>=2.0.0",                # From ngen-forcing (unpinned there)
-  "netCDF4==1.6.3",
+  "geopandas~=1.1.1",             # Match ngen-forcing
+  "shapely~=2.1.2",               # Match ngen-forcing
+  "fiona~=1.10.1",                # Match ngen-forcing
+  "pyproj>=3.2.0,<4.0.0",         # Match ngen-forcing
+  "pandas~=2.3.3",                # Match ngen-forcing
+  "netCDF4~=1.7.3",               # Match ngen-forcing
   "pydantic==2.11.4",
-  "PyYAML~=6.0.2",
-  "numpy==1.26.4",
+  "PyYAML~=6.0.2",                # Match ngen-forcing
+  "numpy~=1.26.4",                # Match ngen-forcing
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "fiona~=1.10.1",                # Match ngen-forcing
   "pyproj>=3.2.0,<4.0.0",         # Match ngen-forcing
   "pandas~=2.3.3",                # Match ngen-forcing
-  "netCDF4~=1.7.3",               # Match ngen-forcing
+  "netCDF4~=1.6.3",               # Match ngen-forcing
   "pydantic==2.11.4",
   "PyYAML~=6.0.2",                # Match ngen-forcing
   "numpy~=1.26.4",                # Match ngen-forcing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "pyproj>=3.2.0,<4.0.0",         # Match ngen-forcing
   "pandas~=2.3.3",                # Match ngen-forcing
   "netCDF4~=1.6.3",               # Match ngen-forcing
-  "pydantic==2.11.4",
+  "pydantic~=2.11.9",
   "PyYAML~=6.0.2",                # Match ngen-forcing
   "numpy~=1.26.4",                # Match ngen-forcing
 ]


### PR DESCRIPTION
This PR includes updates to pyproject.toml to upgrade shapely version from 1 to 2 and to match the pending ngen-forcing pins for other dependencies.