### PR TITLE
Updated the UEB parameter file for the new windspeed height parameter

### DIFF
--- a/src/mswm/module_parameter_files/ueb/ueb_params.dat
+++ b/src/mswm/module_parameter_files/ueb/ueb_params.dat
@@ -63,3 +63,5 @@ a: A in Bristow-Campbell formula for atmospheric transmittance
 0.8      
 c: C in Bristow-Campbell formula for atmospheric transmittance
 2.4 
+Zw: Nominal meas. heights for windspeed
+10 

--- a/src/mswm/module_parameter_files/ueb/ueb_params.dat
+++ b/src/mswm/module_parameter_files/ueb/ueb_params.dat
@@ -64,4 +64,4 @@ a: A in Bristow-Campbell formula for atmospheric transmittance
 c: C in Bristow-Campbell formula for atmospheric transmittance
 2.4 
 Zw: Nominal meas. heights for windspeed
-10 
+10.0


### PR DESCRIPTION
The UEB code has been updated to include a new parameter for the windspeed nominal measurement height parameter. The default value in the parameter is 10 m because this is the value in the NWS forecast and the AORC data. 
Updated the UEB parameter file in this repo. 
Note that the UEB module must be updated to utilize this new parameter. 